### PR TITLE
Upgrade to Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,9 @@ set(QAPPLICATION_CLASS QApplication CACHE STRING "Inheritance class for SingleAp
 add_definitions(-DQT_NO_KEYWORDS)
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(PORTAL-QT REQUIRED IMPORTED_TARGET libportal-qt5)
+pkg_check_modules(PORTAL-QT REQUIRED IMPORTED_TARGET libportal-qt6)
 
-find_package(Qt5 COMPONENTS
+find_package(Qt6 COMPONENTS
         Core
         Gui
         Widgets
@@ -34,10 +34,10 @@ add_executable(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME} PRIVATE src)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
-        Qt5::Core
-        Qt5::Gui
-        Qt5::Widgets
-        Qt5::DBus
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Widgets
+        Qt6::DBus
         PkgConfig::PORTAL-QT
         SingleApplication
 )

--- a/src/ServiceDialog.cpp
+++ b/src/ServiceDialog.cpp
@@ -47,6 +47,11 @@ void ServiceDialog::setupUi() {
     mainLayout->addLayout(lowerRow);
 
     connect(copyToClipboardBtn, &QPushButton::clicked, this, &ServiceDialog::copyToClipboard);
+    /*
+     * QCheckBox::StateChanged emits a deprecation warning on Qt 6.7+.
+     * Don't fix it for now, as the new method was introduced in 6.7,
+     * and e.g. Debian Bookworm ship versions older than that.
+     */
     connect(showUninstall, &QCheckBox::stateChanged, this, &ServiceDialog::toggleCommandContent);
     connect(helpINeedMommy, &QPushButton::clicked, this, &ServiceDialog::openHelpPage);
     connect(confirmButtons, &QDialogButtonBox::helpRequested, this, &ServiceDialog::openHelpPage);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,7 @@
 #include <cstdlib>
 #include <iostream>
 
-#include <libportal-qt5/portal-qt5.h>
+#include <libportal-qt6/portal-qt6.h>
 
 #include "SingleApplication"
 #include "SettingsDialog.h"


### PR DESCRIPTION
I've clicked around in the GUI for a bit and have had this running in the background for a day or so without any issues.

I've also upgraded the flatpak, but can only create that PR once you've actually tagged a Qt 6 version so I can add the correct upstream tag / commit hash.